### PR TITLE
Add NeverMigrate to tapp spec

### DIFF
--- a/pkg/apis/tappcontroller/v1/types.go
+++ b/pkg/apis/tappcontroller/v1/types.go
@@ -76,6 +76,10 @@ type TAppSpec struct {
 	// Default values is false.
 	ForceDeletePod bool `json:"forceDeletePod,omitempty"`
 
+	// NeverMigrate indicates whether to migrate pods. If it is true, pods will never be migrated to
+	// other nodes, otherwise it depends on other conditions(e.g. pod restart policy).
+	NeverMigrate bool `json:"neverMigrate,omitempty"`
+
 	// volumeClaimTemplates is a list of claims that pods are allowed to reference.
 	// The StatefulSet controller is responsible for mapping network identities to
 	// claims in a way that maintains the identity of a pod. Every claim in

--- a/pkg/tapp/controller.go
+++ b/pkg/tapp/controller.go
@@ -552,6 +552,10 @@ func shouldPodMigrate(tapp *tappv1.TApp, pod *corev1.Pod, id string) (bool, erro
 			util.GetTAppFullName(tapp), id, err)
 	}
 
+	if tapp.Spec.NeverMigrate {
+		return false, nil
+	}
+
 	// Containers in pod have not run yet, e.g. kubelet reject the pod.
 	// TODO: It is just a workaround to add `len(pod.Spec.NodeName) != 0` to make old test cases pass.
 	if len(pod.Spec.NodeName) != 0 && len(pod.Status.InitContainerStatuses) == 0 &&

--- a/pkg/tapp/controller_test.go
+++ b/pkg/tapp/controller_test.go
@@ -147,6 +147,13 @@ func TestShouldPodMigrate(t *testing.T) {
 	if err != nil || v != true {
 		t.Errorf("TestShouldPodMigrate failed for pod that no containers have run")
 	}
+
+	// Test case for 'NeverMigrate'
+	tapp.Spec.NeverMigrate = true
+	v, err = shouldPodMigrate(&tapp, &pod, "0")
+	if err != nil || v != false {
+		t.Errorf("TestShouldPodMigrate failed for pod that no containers have run")
+	}
 }
 
 func TestNeedForceDelete(t *testing.T) {


### PR DESCRIPTION
`NeverMigrate` indicates whether to migrate pods. If it is true, pods will never be migrated to other nodes, otherwise it depends on other conditions(e.g. pod restart policy).