### PR TITLE
fig bug for imageID with more than one tags

### DIFF
--- a/pkg/tapp/controller_test.go
+++ b/pkg/tapp/controller_test.go
@@ -346,7 +346,7 @@ func TestIsUpdatingPods(t *testing.T) {
 				{
 					Name:    "containerB",
 					Image:   "2048",
-					ImageID: "123456",
+					ImageID: "12345",
 				},
 			},
 		},
@@ -407,14 +407,15 @@ func TestIsUpdatingPods(t *testing.T) {
 				{
 					Name:    "containerB",
 					Image:   "2048",
-					ImageID: "123456",
+					ImageID: "12345",
 				},
 			},
 		},
 	}
 	pod3 := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels: map[string]string{tappv1.TAppInstanceKey: "3"},
+			Labels:      map[string]string{tappv1.TAppInstanceKey: "3"},
+			Annotations: map[string]string{InPlaceUpdateStateKey: `{"lastContainerStatuses":{"containerA":{"imageID":"1234567"}}}`},
 		},
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{
@@ -433,7 +434,7 @@ func TestIsUpdatingPods(t *testing.T) {
 				{
 					Name:    "containerA",
 					Image:   "docker.io/nginx:1.7.9",
-					ImageID: "123456",
+					ImageID: "1234567",
 				},
 				{
 					Name:    "containerB",
@@ -443,8 +444,108 @@ func TestIsUpdatingPods(t *testing.T) {
 			},
 		},
 	}
-	pods := []*corev1.Pod{pod0, pod1, pod2, pod3}
-	expectedUpdating := map[string]bool{"1": true, "2": true}
+	pod4 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels:      map[string]string{tappv1.TAppInstanceKey: "4"},
+			Annotations: map[string]string{InPlaceUpdateStateKey: `{"lastContainerStatuses":{"containerA":{"imageID":"123456"}}}`},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "containerA",
+					Image: "nginx:1.7.9",
+				},
+				{
+					Name:  "containerB",
+					Image: "2048",
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:    "containerA",
+					Image:   "nginx",  // Image has not been updated
+					ImageID: "123456", //ImageID has not been updated
+				},
+				{
+					Name:    "containerB",
+					Image:   "2048",
+					ImageID: "12345",
+				},
+			},
+		},
+	}
+	pod5 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels:      map[string]string{tappv1.TAppInstanceKey: "5"},
+			Annotations: map[string]string{InPlaceUpdateStateKey: `{"lastContainerStatuses":{"containerA":{"imageID":"1234567"}}}`},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "containerA",
+					Image: "nginx:1.7.9",
+				},
+				{
+					Name:  "containerB",
+					Image: "2048",
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:    "containerA",
+					Image:   "nginx",  // Image has not been updated
+					ImageID: "123456", //ImageID has  been updated
+				},
+				{
+					Name:    "containerB",
+					Image:   "2048",
+					ImageID: "12345",
+				},
+			},
+		},
+	}
+	pod6 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels:      map[string]string{tappv1.TAppInstanceKey: "6"},
+			Annotations: map[string]string{InPlaceUpdateStateKey: `{"lastContainerStatuses":{"containerC":{"imageID":"1234567"}}}`},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "containerA",
+					Image: "nginx:1.7.9",
+				},
+				{
+					Name:  "containerB",
+					Image: "2048",
+				},
+				{
+					Name:  "containerC",
+					Image: "nginx:1.7.9",
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:    "containerA",
+					Image:   "nginx:1.7.9",
+					ImageID: "1234567",
+				},
+				{
+					Name:    "containerB",
+					Image:   "2048",
+					ImageID: "12345",
+				},
+			},
+		},
+	}
+	pods := []*corev1.Pod{pod0, pod1, pod2, pod3, pod4, pod5, pod6}
+	expectedUpdating := map[string]bool{"1": true, "4": true, "6": true}
 	updating := getUpdatingPods(pods)
 	if !reflect.DeepEqual(expectedUpdating, updating) {
 		t.Errorf("Failed to getUpdatingPods, expected: %+v, got: %+v", expectedUpdating, updating)

--- a/pkg/tapp/in_place_update.go
+++ b/pkg/tapp/in_place_update.go
@@ -1,0 +1,75 @@
+/*
+ * Tencent is pleased to support the open source community by making TKEStack available.
+ *
+ * Copyright (C) 2012-2019 Tencent. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * https://opensource.org/licenses/Apache-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tapp
+
+import (
+	"encoding/json"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	// InPlaceUpdateStateKey records the state of inplace-update.
+	// The value of annotation is InPlaceUpdateState.
+	InPlaceUpdateStateKey string = "inplace-update-state"
+)
+
+type InPlaceUpdateState struct {
+	// LastContainerStatuses records the before-in-place-update container statuses. It is a map from ContainerName
+	// to InPlaceUpdateContainerStatus
+	LastContainerStatuses map[string]InPlaceUpdateContainerStatus `json:"lastContainerStatuses"`
+}
+
+// InPlaceUpdateContainerStatus records the statuses of the container that are mainly used
+// to determine whether the InPlaceUpdate is completed.
+type InPlaceUpdateContainerStatus struct {
+	ImageID string `json:"imageID,omitempty"`
+}
+
+//to find these container which will change in update and add they status before update
+func getInPlaceUpdateStateJson(newPod, oldPod *corev1.Pod) error {
+	inPlaceUpdateState := InPlaceUpdateState{
+		LastContainerStatuses: make(map[string]InPlaceUpdateContainerStatus),
+	}
+
+	oldContainerImage := make(map[string]string)
+	for _, container := range oldPod.Spec.Containers {
+		oldContainerImage[container.Name] = container.Image
+	}
+	newContainerImage := make(map[string]string)
+	for _, container := range newPod.Spec.Containers {
+		newContainerImage[container.Name] = container.Image
+	}
+
+	for _, c := range oldPod.Status.ContainerStatuses {
+		if oldContainerImage[c.Name] != newContainerImage[c.Name] {
+			inPlaceUpdateState.LastContainerStatuses[c.Name] = InPlaceUpdateContainerStatus{
+				ImageID: c.ImageID,
+			}
+		}
+	}
+	inPlaceUpdateStateJSON, err := json.Marshal(inPlaceUpdateState)
+	if err != nil {
+		return err
+	}
+	if newPod.Annotations == nil {
+		newPod.Annotations = map[string]string{}
+	}
+	newPod.Annotations[InPlaceUpdateStateKey] = string(inPlaceUpdateStateJSON)
+	return nil
+}

--- a/pkg/tapp/in_place_update_test.go
+++ b/pkg/tapp/in_place_update_test.go
@@ -1,0 +1,132 @@
+/*
+ * Tencent is pleased to support the open source community by making TKEStack available.
+ *
+ * Copyright (C) 2012-2019 Tencent. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * https://opensource.org/licenses/Apache-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tapp
+
+import (
+	"reflect"
+	"testing"
+
+	tappv1 "tkestack.io/tapp/pkg/apis/tappcontroller/v1"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGetInPlaceUpdateStateJson(t *testing.T) {
+	oldPod := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "containerA",
+					Image: "nginx",
+				},
+				{
+					Name:  "containerB",
+					Image: "2048",
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:    "containerA",
+					Image:   "nginx",
+					ImageID: "123456",
+				},
+				{
+					Name:    "containerB",
+					Image:   "2048",
+					ImageID: "12345",
+				},
+			},
+		},
+	}
+	pod0 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{tappv1.TAppInstanceKey: "0"},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "containerA",
+					Image: "nginx",
+				},
+				{
+					Name:  "containerB",
+					Image: "2048",
+				},
+			},
+		},
+	}
+	pod1 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{tappv1.TAppInstanceKey: "1"},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "containerA",
+					Image: "nginx:1.7.9",
+				},
+				{
+					Name:  "containerB",
+					Image: "2048",
+				},
+			},
+		},
+	}
+	pod2 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{tappv1.TAppInstanceKey: "2"},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "containerA",
+					Image: "nginx:1.7.9",
+				},
+				{
+					Name:  "containerB",
+					Image: "2048:v1",
+				},
+			},
+		},
+	}
+	Annotation0 := `{"lastContainerStatuses":{}}`
+	Annotation1 := `{"lastContainerStatuses":{"containerA":{"imageID":"123456"}}}`
+	Annotation2 := `{"lastContainerStatuses":{"containerA":{"imageID":"123456"},"containerB":{"imageID":"12345"}}}`
+	pods := []*corev1.Pod{pod0, pod1, pod2}
+	expectAnnotations := map[string]string{"0": Annotation0, "1": Annotation1, "2": Annotation2}
+	annotations := getAnnotation(oldPod, pods)
+	if !reflect.DeepEqual(expectAnnotations, annotations) {
+		t.Errorf("Failed to GetInPlaceUpdateStateJson, expected: %+v, got: %+v", expectAnnotations, annotations)
+	}
+}
+
+// getAnnotation returns a map whose key is pod id(e.g. "0", "1"), the map records the InPlaceUpdateStateJson in Annotation
+func getAnnotation(oldPod *corev1.Pod, pods []*corev1.Pod) map[string]string {
+	annotations := make(map[string]string)
+	for _, pod := range pods {
+		if err := getInPlaceUpdateStateJson(pod, oldPod); err == nil {
+			if id, err := getPodIndex(pod); err == nil {
+				annotations[id] = pod.Annotations[InPlaceUpdateStateKey]
+			}
+		}
+	}
+	return annotations
+}


### PR DESCRIPTION
before updating, we find the containers will update and add their old status into the annotations of new pod。
When we find some containers that their new ImageID is same as the old and their image tag is different from the expect, we think the pod is in updating.